### PR TITLE
Datatable keep blk

### DIFF
--- a/SplitsEbirdDownloadInto4files.R
+++ b/SplitsEbirdDownloadInto4files.R
@@ -1,66 +1,68 @@
-#this can take a while to run (up to an hour for a decade of state level data)
+# the time this script takes to run will vary with the number of cores available
+# and the amount of RAM. on a computer with 8 cores and 32 GB RAM, this took
+# just under a minute to run on a decade of data.
 
-library(tidyverse)
+library(data.table)
+library(parallel)
+
+
+# number of cores used for file read/writes; one less than all cores available
+n_core <- detectCores() - 1
 
 #read in download from ebird, change this to your file name
-ebird <- read.delim("ebd_US-WI_rehwoo_199501_200012_relSep-2019.txt", sep="\t", header=TRUE, quote = "", stringsAsFactors = FALSE, na.strings=c(""))
+file <- "ebd_US-WI_rehwoo_199501_200012_relSep-2019.txt"
+# read in all columns as character
+ebird <- fread(file, quote = "", na.strings = "", nThread = n_core,
+  check.names = TRUE, colClasses = "character")
 
 #this removes dots from column names, which were spaces
 names(ebird) <- gsub("\\.", "", names(ebird))
 
+#change NAs to blanks
+na_string <- " "  # NAs will be converted to this string
+for (j in seq_along(ebird)) {
+  set(ebird, which(is.na(ebird[[j]])), j, na_string)
+}
+
 ### OBS
 
-ebirdforobs <- ebird
-
-#change NAs to blanks 
-ebirdforobs <- sapply(ebirdforobs, as.character)
-ebirdforobs[is.na(ebirdforobs)] <- " "
-ebirdforobs
-
 #this selects specific columns for obs
-obs <- ebirdforobs[,c(1,2,5,9,10,11,12,24,30,31,41,42,43,44,46)]
+obs <- ebird[,c(1,2,5,9,10,11,12,24,30,31,41,42,43,44,46)]
 
 #export file to csv
-write.csv(obs, file = "obs.csv", row.names=FALSE)
+fwrite(obs, file = "obs.csv", quote = TRUE, nThread = n_core)
+
+rm("obs")  # remove because it's a very large item and we're done with it
 
 ### LOC
 
 #this selects specific columns for loc
 loc <- ebird[,c(1, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27)]
 
-#convert to tibble
-loctib <- as_tibble(loc)
-
 #remove rows with duplicated locations, leaving a file with only unique locations
-nowwithfewer <- loctib[!duplicated(loctib$LOCALITYID), ]
+loc <- loc[!duplicated(loc$LOCALITYID), ]
 
 #export file to csv
-write.csv(nowwithfewer, file = "loc.csv", row.names=FALSE)
+fwrite(loc, file = "loc.csv", quote = TRUE, nThread = n_core)
 
 ### SUB
 
 #this selects specific columns for sub
 sub <- ebird[,c(1, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 45)]
 
-#convert to tibble
-subtib <- as_tibble(sub)
-
 #remove rows with duplicated checklists, leaving a file with only unique checklists
-nowwithfewersubs <- subtib[!duplicated(subtib$SAMPLINGEVENTIDENTIFIER), ]
+sub <- sub[!duplicated(sub$SAMPLINGEVENTIDENTIFIER), ]
 
 #export file to csv
-write.csv(nowwithfewersubs, file = "sub.csv", row.names=FALSE)
+fwrite(sub, file = "sub.csv", quote = TRUE, nThread = n_core)
 
 ### BRD
 
 #this selects specific columns for bird
 bird <- ebird[,c(3, 4, 5, 6, 7, 8)]
 
-#convert to tibble
-birdtib <- as_tibble(bird)
-
 #remove rows with duplicated birds, leaving a file with only unique common names
-nowwithfewerbirds <- birdtib[!duplicated(birdtib$COMMONNAME), ]
+bird <- bird[!duplicated(bird$COMMONNAME), ]
 
 #export file to csv
-write.csv(nowwithfewerbirds, file = "brd.csv", row.names=FALSE)
+fwrite(bird, file = "brd.csv", quote = TRUE, nThread = n_core)

--- a/SplitsEbirdDownloadInto4files.R
+++ b/SplitsEbirdDownloadInto4files.R
@@ -9,9 +9,9 @@ library(parallel)
 # number of cores used for file read/writes; one less than all cores available
 n_core <- detectCores() - 1
 
-#read in download from ebird, change this to your file name
+#read in download from ebird, change this to your file name; read in all columns
+#as character
 file <- "ebd_US-WI_rehwoo_199501_200012_relSep-2019.txt"
-# read in all columns as character
 ebird <- fread(file, quote = "", na.strings = "", nThread = n_core,
   check.names = TRUE, colClasses = "character")
 
@@ -79,6 +79,10 @@ bird <- ebird[,c(3, 4, 5, 6, 7, 8)]
 
 #remove rows with duplicated birds, leaving a file with only unique common names
 bird <- bird[!duplicated(bird$COMMONNAME), ]
+
+# note that the above potentially removes subspecies/form info; to keep this,
+# use the following instead
+# bird <- unique(bird)
 
 #export file to csv
 fwrite(bird, file = "brd.csv", quote = TRUE, nThread = n_core)


### PR DESCRIPTION
Here's an update to keep only the location record with a block id in cases where there are location records with/without block id. Other changes: 1) use data.table throughout (takes about a minute here), 2) read in all columns as character and then set NAs to " " (i.e. effects all all tables not just obs), 3) set global id to "1" in loc (shouldn't effect database as it doesn't appear to be used in that table). Let me know if any of these are no good and I will update accordingly.